### PR TITLE
fixing ssh config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,6 +46,6 @@ RUN mkdir -p /root/.ssh
 RUN touch /root/.ssh/known_hosts
 
 RUN echo "================== Disabling scrict host checking for ssh ====="
-RUN echo -e "Host * \n\t StrictHostKeyChecking no" > /root/.ssh/config
+ADD config /root/.ssh/config
 
 RUN echo 'ALL ALL=(ALL) NOPASSWD:ALL' | tee -a /etc/sudoers

--- a/config
+++ b/config
@@ -1,0 +1,2 @@
+Host * 
+	 StrictHostKeyChecking no


### PR DESCRIPTION
-  the `config` file in ssh folder had incorrect data
- the fix moves an existing config file inside the `/root/.ssh` folder instead of creating it on the fly
